### PR TITLE
Fix: bootstrap flatly theme url

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,13 @@
 import {Routes} from "@angular/router";
 
+import { SearchComponent } from './search/search.component'
+import { LibraryComponent } from './library/library.component'
+import { BookComponent } from './book/book.component'
+
 export const routes: Routes = [
-  //TODO: Define the routes
+  { path: '', redirectTo: 'search', pathMatch: 'full' },
+  { path: 'search', component: SearchComponent },
+  { path: 'library', component: LibraryComponent },
+  { path: 'book/:id', component: BookComponent },
+  { path: '**', redirectTo: 'search' }
 ];

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
         <!--href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css">-->
 
     <link rel="stylesheet"
-        href="https://bootswatch.com/flatly/bootstrap.css">
+        href="https://bootswatch.com/3/flatly/bootstrap.css">
 
 
 


### PR DESCRIPTION
The old url (https://bootswatch.com/flatly/bootstrap.css) is no longer valid and returns 404.